### PR TITLE
docs: use `go install` instead of `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inspired by [aws-azure-login](https://github.com/dtjohnson/aws-azure-login)
 
 ### From source
 ```
-$ go get -u github.com/knqyf263/azaws
+$ go install github.com/knqyf263/azaws@latest
 ```
 
 ### RedHat, CentOS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

'go get' is no longer supported outside a module later v1.18. so using 'go install' instead of 'go get' now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
